### PR TITLE
Latch mouse press edges so sub-frame clicks are never lost

### DIFF
--- a/src/tie_runtime/input/input.c
+++ b/src/tie_runtime/input/input.c
@@ -184,6 +184,11 @@ static int16_t engine_cursor_x, engine_cursor_y;
 static int manual_release;
 static int eat_mouse_buttons;
 static int system_cursor_visible = -1;
+/* Press edges waiting to be seen by TieInput_GetMousePosition, in DOS button
+ * order (bit 0 = left, bit 1 = right, bit 2 = middle), and the subset already
+ * reported during the current host frame. See TieInput_GetMousePosition. */
+static int16_t s_pending_click_buttons;
+static int16_t s_observed_click_buttons;
 
 static float TieInput_Clamp(float v, float lo, float hi) { return v < lo ? lo : (v > hi ? hi : v); }
 
@@ -217,6 +222,16 @@ void TieInput_GetMousePosition(int16_t* buttons, int16_t* x, int16_t* y) {
 			btn |= 2;
 		if (in->mouse.buttons & AERON_MOUSE_BUTTON_MIDDLE)
 			btn |= 4;
+		/* Report press edges that the engine has not observed yet. A click
+		 * whose down and up events arrive within one event pump (trackpad
+		 * taps) never shows in the level state, and the engine does not
+		 * sample the mouse on every host frame (fade/present task phases
+		 * skip it), so a one-frame edge can vanish unseen. The latch keeps
+		 * the press visible until a sample reports it; the following
+		 * frame's level then supplies the release. */
+		const int16_t inject = s_pending_click_buttons & ~btn;
+		btn |= inject;
+		s_observed_click_buttons |= inject;
 	}
 
 	if (buttons)
@@ -484,7 +499,28 @@ void TieInput_BeginFrame(int32_t delta_us) {
 
 	if (!in) {
 		memset(suppressed_keys, 0, sizeof suppressed_keys);
+		s_pending_click_buttons = 0;
+		s_observed_click_buttons = 0;
 		return;
+	}
+
+	/* Retire press latches a sample reported in an earlier host frame, then
+	 * accumulate this frame's press edges. Focus loss drops pending presses
+	 * so a stale edge cannot replay as a phantom click on refocus. */
+	s_pending_click_buttons &= (int16_t)~s_observed_click_buttons;
+	s_observed_click_buttons = 0;
+	if (eat_mouse_buttons) {
+		/* This frame's press re-engaged capture; it must not surface later. */
+		s_pending_click_buttons = 0;
+	} else if (in->has_focus) {
+		if (in->mouse.pressed_buttons & AERON_MOUSE_BUTTON_LEFT)
+			s_pending_click_buttons |= 1;
+		if (in->mouse.pressed_buttons & AERON_MOUSE_BUTTON_RIGHT)
+			s_pending_click_buttons |= 2;
+		if (in->mouse.pressed_buttons & AERON_MOUSE_BUTTON_MIDDLE)
+			s_pending_click_buttons |= 4;
+	} else {
+		s_pending_click_buttons = 0;
 	}
 	if (capture_active) {
 		if (!in->has_focus || delta_us <= 0 || delta_us > 250000) {


### PR DESCRIPTION
## Problem

Mouse clicks in the frontend frequently fail to register unless the button is held down, and feel very delayed when they do (reported in #9, observed on macOS 0.0.1).

`TieInput_GetMousePosition` forwards only the level state of `AeronInputSnapshot.mouse.buttons`. A click whose down and up events arrive within a single event pump never shows up in the level state at all — macOS trackpad taps deliver both events within ~100 µs of each other, so every snapshot reads "released" and the click is invisible to the engine.

Instrumented timelines (SDL event → snapshot sample → Landru button state) confirmed taps with down/up in the same host frame produced no reaction in `lio_Poll_Fast_Mouse_Input` / `lio_Poll_Input`, while held clicks always registered.

Exposing the press edge (`pressed_buttons`) for one host frame turned out to be insufficient as well: the frontend does not sample the mouse on every host frame — the fade/present task phases skip it — so a one-frame edge still vanished unseen in roughly half of the test taps.

## Fix

Latch press edges in `TieInput_BeginFrame` and keep reporting the button as held until a `TieInput_GetMousePosition` sample has actually observed it; the following frame's level state then supplies the release. Landru's existing `fast_button_gbl` latch handles the rest exactly as it handled the original 250 Hz interrupt polling.

Safeguards: pending presses are dropped on focus loss and when the press re-engaged flight capture (`eat_mouse_buttons`), so a stale edge cannot replay as a phantom click. Held clicks behave as before (the level state masks the latch); the only behavioral change for a hold is that the release can be reported one host frame later.

## Testing

Debug build on macOS arm64 (Sequoia, trackpad): with instrumentation, every sub-frame tap (60–100 µs down→up) now completes the full chain — press latched → concourse registers down → release fires. Before the change the same taps were dropped whenever they landed on a host frame without a mouse sample. Held clicks, drags (map/slider widgets), right-click, focus loss mid-press, and flight capture re-engagement behave unchanged.

Fixes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)